### PR TITLE
Prevent autoupdate.php from being run from the browser.

### DIFF
--- a/autoupdate.php
+++ b/autoupdate.php
@@ -1,5 +1,6 @@
 <?php
 
+require_once('cli_only.php');
 require_once('update.php');
 //echo "TESTING = " . $testing;
 update();

--- a/cli_only.php
+++ b/cli_only.php
@@ -1,0 +1,4 @@
+<?php
+
+if (php_sapi_name() !== "cli")
+    die("This is not meant to be run from a Web server. Aborting.\n");


### PR DESCRIPTION
This makes autoupdate.php abort if run from the browser at https://super-challenge.language-learners.org/

As it stands now, adding /autoupdate.php to the above URL will run the worker script, which could cause twits to be processed twice, or for some of them to be ignored, etc. as the update machinery relies on a knowing the last twit it processed and moving on from there but doesn't check to make sure there is only one update script running.

It's been tested via docker-compose with the provided configuration.

Cheers